### PR TITLE
^ fix for dst type issue

### DIFF
--- a/ConICDSQL.usc
+++ b/ConICDSQL.usc
@@ -31,6 +31,7 @@ start ConICDSQL(parmfile, option, retcode)
    hdr[]             is  x       ' Report header lines
    reportFmt         is  x       ' Report Detail Format Line
    PrintString       is  x       ' Output Concatenation String
+   dsttype           is  x       ' dst type code - use for setting gaf type
 
 ' Prompts
    reportOnly        is  x       ' Flag for report only (Y/N)
@@ -73,7 +74,7 @@ start ConICDSQL(parmfile, option, retcode)
    c.dxaxlvl8        is x         ' AXIS 4 H DIAGNOSIS DST
    c.dxaxlvl9        is x         ' AXIS 4 I DIAGNOSIS DST
    c.dxaxlvl0        is x         ' AXIS 4 J DIAGNOSIS DST
-   c.pa.aav          is x         ' GAF CURRENT SCORE DST
+   c.pa.aav          is v         ' GAF CURRENT SCORE DST
 
 'C.ASSESOTH   is x   Outside Assessing Staff Name
    C.DXACT           is x         ' Reason for Action
@@ -293,6 +294,9 @@ start ConICDSQL(parmfile, option, retcode)
    if tracepath dp then
       $trace("path,on", tracepath)
    endif
+
+   dsttype = $dsttype(c.pa.aav)
+   $setvartype(c.pa.aav, dsttype) 
 
    rc = $loadlib(libf,"LIB-freetds")
 


### PR DESCRIPTION
> issue reported by frank
>    : issue : different systems have implemented dst types for some dx dsts differently. Namely the GAF dst could be Alpha type or Numeric type.
>    : fix :
>       \* change the dst gaf to be a variant type
>       \* after dst name mapping check the dst type with `$dsttype()` system function
>       \* set the gaf dst variable to the dst type returned from `$dsttype()` with `$setvartype()` system function

modified:   ConICDSQL.usc
