### PR TITLE
ICD 9 'General' to ICD 10 'Unspecified' Mapping support update

### DIFF
--- a/ConICDSQL.usc
+++ b/ConICDSQL.usc
@@ -37,6 +37,7 @@ start ConICDSQL(parmfile, option, retcode)
    reportOnly        is  x       ' Flag for report only (Y/N)
    done              is  x       ' Flag for Ready to Run
    tracepath         is  x       ' Flag and path to trace execution
+   hasdots           is  x       ' Flag to remove dots from the icd codes (Y|!dp)
 
 
 ' Client DSTs
@@ -211,8 +212,12 @@ start ConICDSQL(parmfile, option, retcode)
    o_host             is x
    o_db               is x
 
+   ICD10_Table        is x
+   ICD9_Table         is x
+
    dsn                is x
    libf               is b
+   lib-dx             is b
 
    list_sql           is x
    save_sql_list      is x
@@ -227,6 +232,7 @@ start ConICDSQL(parmfile, option, retcode)
    TheRow[]           is x
    TheColumn[]        is x
    TheLevel           is i
+   TheAxis            is x
 
 '=================================================
 'Initializations
@@ -299,6 +305,12 @@ start ConICDSQL(parmfile, option, retcode)
 
    dsn = o_user + ":" + o_pass + ":" + o_host + ":" + o_db
    libf:setDSN(dsn)
+
+   rc = $loadlib(lib-dx, "lib_DX10")
+
+    ICD10_Table = "[t_ICD-10_ICD-10_with_GEM_AXIS]"
+    ICD9_Table = "[t_ICD-10_ICD-9_with_GEM_AXIS]"
+   lib-dx:Set_Sql(o_user, o_pass, o_host, o_db, icd10_table, icd9_table)
 
    ' create the list from sql? 
    if list_sql dp then
@@ -452,6 +464,7 @@ convertErr = "N"        ' No conversion Error
 ' Handle Data conversion in each Axis, and modify codes as needed.
 '============================================================================
       ' Axis 1
+      TheAxis = "1"
       if (c.pa.aai  DP
          and c.pa.aai  != "V7109"
          and c.pa.aai  != "79990"
@@ -507,6 +520,7 @@ convertErr = "N"        ' No conversion Error
       endif
 
       ' Axis 2
+      TheAxis = "2"
       if (c.pa.aaii DP
          and c.pa.aaii != "V7109"
          and c.pa.aaii != "79990"
@@ -562,6 +576,7 @@ convertErr = "N"        ' No conversion Error
       endif
 
               ' Axis 3
+      TheAxis = "3"
       if (c.pa.aaiii DP
          and c.pa.aaiii != "NONE"
          and c.pa.aaiii != "V7109"
@@ -677,6 +692,7 @@ convertErr = "N"        ' No conversion Error
       endif
 
       ' Axis 4
+      TheAxis = "4"
       $clear(axis4Code[])
 
       ' Stick all the Axis 4 Codes into one array
@@ -716,6 +732,7 @@ convertErr = "N"        ' No conversion Error
       (void) $arrCompress(axis4Code[])
 
 
+      $clear(TheAxis)
       ' Did we have an conversion error
       if (convertErr != "N") then
          errCount++
@@ -935,6 +952,8 @@ SQLLookup:
       TheEffDt[TheLevel] = TheColumn[8]
       TheEndDt[TheLevel] = TheColumn[9]
 
+   elseif TheCount > 1 then
+      lib-dx:DX_9Code_Query(TheCode,TheAxis,hasdots,results[],"%unspecified%")
    else
       convertErr = TheError ' Set the error Flag
    endif

--- a/ConICDSQL.usc
+++ b/ConICDSQL.usc
@@ -295,9 +295,6 @@ start ConICDSQL(parmfile, option, retcode)
       $trace("path,on", tracepath)
    endif
 
-   dsttype = $dsttype(c.pa.aav)
-   $setvartype(c.pa.aav, dsttype) 
-
    rc = $loadlib(libf,"LIB-freetds")
 
    dsn = o_user + ":" + o_pass + ":" + o_host + ":" + o_db
@@ -354,6 +351,9 @@ start ConICDSQL(parmfile, option, retcode)
    $setvarname(c.pa.aav    , MAP_c.pa.aav    )  
    $setvarname(C.DXACT     , MAP_C.DXACT     )  
    $setvarname(C.CR.DIAG   , MAP_C.CR.DIAG   )  
+
+   dsttype = $dsttype(c.pa.aav)
+   $setvartype(c.pa.aav, dsttype) 
 
 '=================================================
 ' Some Screen / Prompt Stuff

--- a/deploy.js
+++ b/deploy.js
@@ -34,4 +34,5 @@ mis.parm.fromflatfile('./icdmap.ignore')
    return mis.parm.tofile('./build/ICDMAP.parm', parm)
 })
 .then(mis.deploy.parm)
+//.then(mis.script.install.bind(mis, './ConICDSQL.usc'));
 .then(mis.script.runonce.bind(mis, './ConICDSQL.usc'));

--- a/readme.md
+++ b/readme.md
@@ -11,3 +11,18 @@ diagnosis is not converted.
 
 Extract a list ofICD 10 Diagnosis from the clients to import into SQL
 
+### Install Instructions
+
+Copy the ConICDSQL.usc script to $SYS/SCRIPT/S and compile with the Uscript Maintenance program.
+
+Copy Paste the contents of the ICDMAP.ignore file into a parameter file using the Parameter File Maintenance Program. Edit the content to match the dsts and variables of your system by removing the values in the curly brackets and the brackets themselves.
+
+*For Example*
+
+`MAP_c.dx.rh {{dx record header}}`
+
+Will need to be edited to:
+
+`MAP_c.dx.rh C.DX.REC`
+
+where `C.DX.REC` is the name of the dst record header for you legacy diagnosis record head.


### PR DESCRIPTION
- ICD 9 'General' to ICD 10 'Unspecified'
  update to conversion logic to decrease the number of failed conversions

> new logic apptempts to map ICD 9 codes that return multiple possible ICD10 codes
>    by completing another search but looking for codes with a description that is
>    LIKE %unspecified%. If 1 code is returned by that search then that code is used
>    for the conversion.

: note : ConICDSQL.usc is now dependent on [lib_DX10.usc](http://github.com/txace/icd10-sql)
